### PR TITLE
fix(ci): restrict workflow token permissions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,6 +3,9 @@ name: Benchmark
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   native-comparison:
     name: WASM vs native

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Node ${{ matrix.node }}


### PR DESCRIPTION
## Summary

- restrict CI workflow tokens to read-only repository contents
- apply the same least-privilege declaration to the benchmark workflow

## CodeQL

- resolves [alert #1](https://github.com/openclaw/libopus-wasm/security/code-scanning/1)
- resolves [alert #2](https://github.com/openclaw/libopus-wasm/security/code-scanning/2)

## Testing

- `actionlint .github/workflows/benchmark.yml .github/workflows/ci.yml`
- `git diff --check origin/main...HEAD`
