### PR TITLE
fix(ci): restrict workflow token permissions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,6 +3,9 @@ name: Benchmark
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   native-comparison:
     name: WASM vs native

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Node ${{ matrix.node }}


### PR DESCRIPTION
## Summary

- set explicit workflow-level `contents: read` permissions for CI and the manual benchmark
- keep every existing trigger, action, command, matrix entry, and Emscripten setting unchanged
- supersede the approach in https://github.com/openclaw/libopus-wasm/pull/5 without modifying that reference PR

## Root cause

Both workflows relied on inherited repository defaults for `GITHUB_TOKEN`. The workflow owner should declare the smallest stable token contract directly.

## Permission matrix

- `actions/checkout@v7`: requires repository contents read access to fetch the source tree
- `pnpm/action-setup@v6`: installs pnpm and reads local package metadata; no repository write permission
- `actions/setup-node@v6`: resolves Node and uses the Actions cache service; no repository write permission
- `emscripten-core/setup-emsdk@v16`: downloads/caches the SDK; no repository write permission
- install, build, test, pack, and benchmark commands: local filesystem/network work only

## Verification

- `actionlint .github/workflows/benchmark.yml .github/workflows/ci.yml`
- YAML parse of both workflows
- Emscripten 5.0.7: `pnpm build`
- Emscripten 5.0.7: `pnpm test` (20/20)
- `pnpm pack --dry-run`
- `pnpm benchmark` (20,000 iterations; native and WASM encode/decode completed)
- AWS Crabbox exact-head build/test/pack: https://crabbox.openclaw.ai/portal/runs/run_d3af0ad48ecb
- Codex Sol/high autoreview and test audit: clean, 0.99 confidence

## Security scope

- addresses CodeQL alerts https://github.com/openclaw/libopus-wasm/security/code-scanning/1 and https://github.com/openclaw/libopus-wasm/security/code-scanning/2
- leaves alert https://github.com/openclaw/libopus-wasm/security/code-scanning/3 for the separate docs-sanitizer lane
- no alert dismissal, release, schedule, signing, deployment, or repository-setting changes

## LOC

- workflow/config: `+6/-0`
- production: `0`
- tests: `0`

## ClawSweeper

- exact-head immutable review artifact: correctness cleared at 0.96 confidence; no findings, risks, or maintainer decision required
- rank-up move: consolidate duplicate drafts
- skip: PR #5 remains untouched because this campaign has no proven exclusive lease for that pre-existing branch/PR; this PR is the canonical campaign-owned candidate
