### PR TITLE
fix(docs): derive TOC from renderer headings

### DIFF
--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -62,15 +62,15 @@ for (const section of nav) for (const page of section.pages) sectionByRel.set(pa
 const orderedPages = nav.flatMap((s) => s.pages);
 
 for (const page of pages) {
-  const html = markdownToHtml(page.markdown, page.rel);
-  const toc = tocFromHtml(html);
+  const rendered = renderMarkdown(page.markdown, page.rel);
+  const toc = renderToc(rendered.headings);
   const idx = orderedPages.findIndex((p) => p.rel === page.rel);
   const prev = idx > 0 ? orderedPages[idx - 1] : null;
   const next = idx >= 0 && idx < orderedPages.length - 1 ? orderedPages[idx + 1] : null;
   const sectionName = sectionByRel.get(page.rel) || "Reference";
   const pageOut = path.join(outDir, page.outRel);
   fs.mkdirSync(path.dirname(pageOut), { recursive: true });
-  fs.writeFileSync(pageOut, layout({ page, html, toc, prev, next, sectionName }), "utf8");
+  fs.writeFileSync(pageOut, layout({ page, html: rendered.html, toc, prev, next, sectionName }), "utf8");
 }
 
 fs.writeFileSync(path.join(outDir, "favicon.svg"), faviconSvg(), "utf8");
@@ -196,7 +196,15 @@ function titleize(input) {
   return input.replaceAll("-", " ").replace(/\b\w/g, (m) => m.toUpperCase());
 }
 
-function markdownToHtml(markdown, currentRel) {
+function renderMarkdown(markdown, currentRel) {
+  const context = { headings: [], headingIds: new Set() };
+  return {
+    html: markdownToHtml(markdown, currentRel, context),
+    headings: context.headings,
+  };
+}
+
+function markdownToHtml(markdown, currentRel, context) {
   const lines = markdown.replace(/\r\n/g, "\n").split("\n");
   const html = [];
   let paragraph = [];
@@ -206,7 +214,7 @@ function markdownToHtml(markdown, currentRel) {
 
   const flushParagraph = () => {
     if (!paragraph.length) return;
-    html.push(`<p>${inline(paragraph.join(" "), currentRel)}</p>`);
+    html.push(`<p>${inline(paragraph.join(" "), currentRel).html}</p>`);
     paragraph = [];
   };
   const closeList = () => {
@@ -216,7 +224,7 @@ function markdownToHtml(markdown, currentRel) {
   };
   const flushBlockquote = () => {
     if (!blockquote.length) return;
-    const inner = markdownToHtml(blockquote.join("\n"), currentRel);
+    const inner = markdownToHtml(blockquote.join("\n"), currentRel, context);
     html.push(`<blockquote>${inner}</blockquote>`);
     blockquote = [];
   };
@@ -289,12 +297,15 @@ function markdownToHtml(markdown, currentRel) {
       closeList();
       const level = heading[1].length;
       const text = heading[2].trim();
-      const id = slug(text);
       const inner = inline(text, currentRel);
+      const id = uniqueHeadingId(text, context.headingIds);
+      if (level === 2 || level === 3) {
+        context.headings.push({ level, id, label: inner.text });
+      }
       if (level === 1) {
-        html.push(`<h1 id="${id}">${inner}</h1>`);
+        html.push(`<h1 id="${id}">${inner.html}</h1>`);
       } else {
-        html.push(`<h${level} id="${id}"><a class="anchor" href="#${id}" aria-label="Anchor link">#</a>${inner}</h${level}>`);
+        html.push(`<h${level} id="${id}"><a class="anchor" href="#${id}" aria-label="Anchor link">#</a>${inner.html}</h${level}>`);
       }
       continue;
     }
@@ -313,8 +324,8 @@ function markdownToHtml(markdown, currentRel) {
         i += 1;
         rows.push(splitRow(lines[i]));
       }
-      const th = header.map((c, idx) => `<th${aligns[idx] ? ` style="text-align:${aligns[idx]}"` : ""}>${inline(c, currentRel)}</th>`).join("");
-      const tb = rows.map((r) => `<tr>${r.map((c, idx) => `<td${aligns[idx] ? ` style="text-align:${aligns[idx]}"` : ""}>${inline(c, currentRel)}</td>`).join("")}</tr>`).join("");
+      const th = header.map((c, idx) => `<th${aligns[idx] ? ` style="text-align:${aligns[idx]}"` : ""}>${inline(c, currentRel).html}</th>`).join("");
+      const tb = rows.map((r) => `<tr>${r.map((c, idx) => `<td${aligns[idx] ? ` style="text-align:${aligns[idx]}"` : ""}>${inline(c, currentRel).html}</td>`).join("")}</tr>`).join("");
       html.push(`<table><thead><tr>${th}</tr></thead><tbody>${tb}</tbody></table>`);
       continue;
     }
@@ -328,7 +339,7 @@ function markdownToHtml(markdown, currentRel) {
         list = tag;
         html.push(`<${tag}>`);
       }
-      html.push(`<li>${inline((bullet || numbered)[1], currentRel)}</li>`);
+      html.push(`<li>${inline((bullet || numbered)[1], currentRel).html}</li>`);
       continue;
     }
     paragraph.push(line.trim());
@@ -341,19 +352,28 @@ function markdownToHtml(markdown, currentRel) {
 
 function inline(text, currentRel) {
   const stash = [];
-  let out = text.replace(/`([^`]+)`/g, (_, code) => {
-    stash.push(`<code>${escapeHtml(code)}</code>`);
+  const source = text.replace(/`([^`]+)`/g, (_, code) => {
+    stash.push({ html: `<code>${escapeHtml(code)}</code>`, text: code });
     return `${String.fromCharCode(0)}${stash.length - 1}${String.fromCharCode(0)}`;
   });
-  out = escapeHtml(out)
+  let html = escapeHtml(source)
     .replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>")
     .replace(/(^|[^*])\*([^*\s][^*]*?)\*(?!\*)/g, "$1<em>$2</em>")
     .replace(/(^|[^_])_([^_\s][^_]*?)_(?!_)/g, "$1<em>$2</em>")
     .replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_, label, href) => `<a href="${escapeAttr(rewriteHref(href, currentRel))}">${label}</a>`)
     .replace(/&lt;(https?:\/\/[^\s<>]+)&gt;/g, '<a href="$1">$1</a>');
-  out = out.replace(/\\\|/g, "|");
-  out = out.replace(/&lt;br&gt;/g, "<br>");
-  return out.replace(new RegExp(String.fromCharCode(0) + "([0-9]+)" + String.fromCharCode(0), "g"), (_, i) => stash[Number(i)]);
+  html = html.replace(/\\\|/g, "|").replace(/&lt;br&gt;/g, "<br>");
+  const label = source
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/(^|[^*])\*([^*\s][^*]*?)\*(?!\*)/g, "$1$2")
+    .replace(/(^|[^_])_([^_\s][^_]*?)_(?!_)/g, "$1$2")
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
+    .replace(/<(https?:\/\/[^\s<>]+)>/g, "$1")
+    .replace(/\\\|/g, "|")
+    .replace(/<br>/g, "");
+  const restore = (value, key) =>
+    value.replace(/\u0000(\d+)\u0000/g, (_, i) => stash[Number(i)][key]);
+  return { html: restore(html, "html"), text: restore(label, "text") };
 }
 
 function rewriteHref(href, currentRel) {
@@ -378,20 +398,10 @@ function rewriteHref(href, currentRel) {
   return `${rewritten}${hash ? `#${hash}` : ""}`;
 }
 
-function tocFromHtml(html) {
-  const items = [];
-  const re = /<h([23]) id="([^"]+)">([\s\S]*?)<\/h[23]>/g;
-  let m;
-  while ((m = re.exec(html))) {
-    const text = m[3]
-      .replace(/<a class="anchor"[^>]*>.*?<\/a>/, "")
-      .replace(/<[^>]+>/g, "")
-      .trim();
-    items.push({ level: Number(m[1]), id: m[2], text });
-  }
+function renderToc(items) {
   if (items.length < 2) return "";
   return `<nav class="toc" aria-label="On this page"><h2>On this page</h2>${items
-    .map((i) => `<a class="toc-l${i.level}" href="#${i.id}">${escapeHtml(i.text)}</a>`)
+    .map((i) => `<a class="toc-l${i.level}" href="#${i.id}">${escapeHtml(i.label)}</a>`)
     .join("")}</nav>`;
 }
 
@@ -573,6 +583,14 @@ function hrefToOutRel(targetOutRel, currentOutRel) {
 
 function slug(text) {
   return text.toLowerCase().replace(/`/g, "").replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+function uniqueHeadingId(text, usedIds) {
+  const base = slug(text) || "section";
+  let id = base;
+  for (let suffix = 2; usedIds.has(id); suffix += 1) id = `${base}-${suffix}`;
+  usedIds.add(id);
+  return id;
 }
 
 function escapeHtml(value) {

--- a/test/docs-site.test.ts
+++ b/test/docs-site.test.ts
@@ -1,0 +1,110 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const builder = path.join(repoRoot, "scripts", "build-docs-site.mjs");
+
+function buildPage(body: string): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "libopus-docs-test-"));
+  const docs = path.join(root, "docs");
+  fs.mkdirSync(docs);
+
+  try {
+    const writeDoc = (name: string, content: string) =>
+      fs.writeFileSync(path.join(docs, name), content);
+    writeDoc("index.md", "# Home\n\nWelcome.\n");
+    writeDoc("install.md", "# Install\n\nInstall locally.\n");
+    writeDoc("quickstart.md", "# Quickstart\n\nStart locally.\n");
+    writeDoc("api-reference.md", body);
+
+    execFileSync(process.execPath, [builder], { cwd: root });
+    const first = fs.readFileSync(
+      path.join(root, "dist", "docs-site", "api-reference.html"),
+      "utf8",
+    );
+    execFileSync(process.execPath, [builder], { cwd: root });
+    const second = fs.readFileSync(
+      path.join(root, "dist", "docs-site", "api-reference.html"),
+      "utf8",
+    );
+
+    expect(second).toBe(first);
+    return first;
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function pageToc(page: string): string {
+  const toc = page.match(/<nav class="toc"[\s\S]*?<\/nav>/)?.[0];
+  expect(toc).toBeDefined();
+  return toc!;
+}
+
+describe("docs site headings", () => {
+  it("escapes malicious heading text once in the TOC", () => {
+    const page = buildPage(
+      [
+        "# API reference",
+        "",
+        "## Safe",
+        "",
+        '## <img src=x onerror=alert("toc")> <scr<script>ipt>alert("toc")</scr<script>ipt>',
+        "",
+      ].join("\n"),
+    );
+    const toc = pageToc(page);
+
+    expect(toc).toBe(
+      '<nav class="toc" aria-label="On this page"><h2>On this page</h2>' +
+        '<a class="toc-l2" href="#safe">Safe</a>' +
+        '<a class="toc-l2" href="#img-src-x-onerror-alert-toc-scr-script-ipt-alert-toc-scr-script-ipt">' +
+        '&lt;img src=x onerror=alert(&quot;toc&quot;)&gt; ' +
+        '&lt;scr&lt;script&gt;ipt&gt;alert(&quot;toc&quot;)&lt;/scr&lt;script&gt;ipt&gt;</a></nav>',
+    );
+    expect(toc).not.toMatch(/&amp;lt;|<img|<script/i);
+  });
+
+  it("renders deterministic labels and unique anchors from heading facts", () => {
+    const page = buildPage(
+      [
+        "# API reference",
+        "",
+        "## Repeat",
+        "",
+        "> ### **Nested [label](https://example.com)** and `code`",
+        "",
+        "## Repeat",
+        "",
+        "## Repeat 2",
+        "",
+        "### Fish &amp; Chips",
+        "",
+      ].join("\n"),
+    );
+    const toc = pageToc(page);
+
+    expect(toc).toBe(
+      '<nav class="toc" aria-label="On this page"><h2>On this page</h2>' +
+        '<a class="toc-l2" href="#repeat">Repeat</a>' +
+        '<a class="toc-l3" href="#nested-label-https-example-com-and-code">Nested label and code</a>' +
+        '<a class="toc-l2" href="#repeat-2">Repeat</a>' +
+        '<a class="toc-l2" href="#repeat-2-2">Repeat 2</a>' +
+        '<a class="toc-l3" href="#fish-amp-chips">Fish &amp;amp; Chips</a></nav>',
+    );
+
+    const headingIds = [...page.matchAll(/<h[23] id="([^"]+)"/g)].map(
+      (match) => match[1],
+    );
+    const tocIds = [...toc.matchAll(/href="#([^"]+)"/g)].map((match) => match[1]);
+    expect(tocIds).toEqual(headingIds);
+    expect(new Set(headingIds).size).toBe(headingIds.length);
+    expect(page).toMatch(
+      /<h3 id="nested-label-https-example-com-and-code">[^<]*<a class="anchor"[^>]*>#<\/a><strong>Nested <a href="https:\/\/example\.com">label<\/a><\/strong> and <code>code<\/code><\/h3>/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- stop deriving table-of-contents labels by regex-stripping rendered HTML
- carry renderer-owned heading labels and IDs into TOC rendering
- assign deterministic unique anchors to duplicate and colliding headings

## Root cause

The docs builder serialized heading HTML and then reparsed it with a multi-character regex replacement. Crafted tag fragments survived as doubly escaped text, entities were escaped again, and repeated headings reused the same anchor. The renderer now records structured heading facts while parsing Markdown and the TOC escapes those labels once at its output boundary.

## Verification

- pre-fix regression: both focused docs tests failed on double/triple escaping and duplicate IDs
- `node node_modules/vitest/vitest.mjs run test/docs-site.test.ts`
- `node scripts/build-docs-site.mjs`
- `node --check scripts/build-docs-site.mjs`
- `node node_modules/typescript/bin/tsc -p tsconfig.json --noEmit`
- generated-site comparison: only the duplicate `Properties` and `Methods` anchors in `api-reference.html` changed, receiving `-2` suffixes with matching TOC links
- Sol/high autoreview and test-value audit: clean, confidence 0.98
- local package build could not start because this host lacks `emconfigure`
- exact-head CI and CodeQL: green
- Crabbox: [run `run_9182226f9457`](https://crabbox.openclaw.ai/portal/runs/run_9182226f9457) passed Emscripten 5.0.7 package build, all 22 tests, docs build, pack dry-run, and generated duplicate-anchor assertions; the fresh AWS lease stopped cleanly

## Scope

- production: `+48/-30` (net `+18`)
- tests: `+110/-0`
- dependencies: `0`
- generated files: `0`

CodeQL alert: https://github.com/openclaw/libopus-wasm/security/code-scanning/3

Exact-head CI, CodeQL, Crabbox, and the immutable ClawSweeper review are complete. ClawSweeper reported no findings; its delayed public publisher is not a landing blocker under repository policy, and its sole rank-up move (mark ready) is satisfied.
