### PR TITLE
build: enable pnpm trust-policy downgrade checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Generate documentation table-of-contents links from rendered headings so code-formatted, repeated, and punctuated headings link correctly. (#7) Thanks @vincentkoc.
 - Raise the minimum supported Node.js version from 20 to 22.
 - Refresh pnpm to 11.25.0, TypeScript to 7.0.2, Node.js types to 26.4.1, Vite to 8.2.2, and Vitest and V8 coverage to 5.0.0; refresh transitive dependencies and GitHub Actions, build with Emscripten 6.0.9, and test through Node.js 26. Running the test suite requires Node.js 22.12 or newer.
+- Reject dependency releases with downgraded publisher trust evidence while preserving the 48-hour release-age policy. (#8) Thanks @anupamme.
 
 ## 0.2.0 - 2026-06-01
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,11 +1,14 @@
 packages:
   - "."
 
+trustPolicy: no-downgrade
+blockExoticSubdeps: true
+
 allowBuilds:
   '@discordjs/opus': true
   esbuild: true
 
-minimumReleaseAge: 2880
+minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
   - vite@8.1.2
   - '@typescript/typescript-aix-ppc64@7.0.2'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,13 +2,12 @@ packages:
   - "."
 
 trustPolicy: no-downgrade
-blockExoticSubdeps: true
 
 allowBuilds:
   '@discordjs/opus': true
   esbuild: true
 
-minimumReleaseAge: 10080
+minimumReleaseAge: 2880
 minimumReleaseAgeExclude:
   - vite@8.1.2
   - '@typescript/typescript-aix-ppc64@7.0.2'


### PR DESCRIPTION
Enable pnpm's `trustPolicy: no-downgrade` so dependency installation rejects releases whose publisher trust evidence has decreased. Preserve the existing 48-hour `minimumReleaseAge: 2880` policy and rely on pnpm's existing exotic-subdependency default.

Rebased onto main after #16 and #17 landed. The final diff adds only the trust-policy setting and a credited Unreleased entry beneath the tooling bullet. Thanks @anupamme for the original hardening proposal.

Validation on head `84e892f685c206571df7310bbe95ec87246e3faf`, using Node.js 26.8.1 and pnpm 11.25.0:

```text
$ pnpm config get trustPolicy
no-downgrade
$ pnpm config get minimumReleaseAge
2880
$ pnpm install --frozen-lockfile
Verifying lockfile against supply-chain policies (153 entries)...
Lockfile passes supply-chain policies (153 entries in 1s)
Done in 1m 34.3s using pnpm v11.25.0
```

The full installation succeeded, including the native comparison addon's source-build fallback after its Node 26 prebuilt download returned 404. The lockfile is unchanged. Codex local and committed-branch autoreview are scoped-clean through P2.

Hosted CI: https://github.com/openclaw/libopus-wasm/actions/runs/33989264668
