### PR TITLE
fix: destroy encoder if post-create option setters throw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Destroy the native encoder if post-create option setters throw, and reject invalid `complexity`, `packetLossPercent`, and `signal` before WASM create.
 - Update pnpm, Node.js types, Vite, Vitest and coverage tooling, refresh transitive dependency pins, and build CI with Emscripten 6.0.8 and setup-node v7.
 - Refresh pnpm, TypeScript, Node.js types, Vite, and GitHub Actions; pin patched transitive build tooling and extend CI coverage through Node.js 26.
 - Require Node.js 22 or newer for the npm package, matching the maintained CI matrix.

--- a/src/index.ts
+++ b/src/index.ts
@@ -280,20 +280,28 @@ class WasmOpusEncoder implements OpusEncoderHandle {
     } finally {
       module._free(errorPtr);
     }
-    this.setBitrate(options.bitrate);
-    this.setComplexity(options.complexity);
-    this.setDtx(options.dtx);
-    this.setFec(options.fec);
-    if (options.maxBandwidth !== undefined) {
-      this.setMaxBandwidth(options.maxBandwidth);
-    }
-    this.setPacketLossPercent(options.packetLossPercent);
-    this.setSignal(options.signal);
-    if (options.vbr !== undefined) {
-      this.setVbr(options.vbr);
-    }
-    if (options.vbrConstraint !== undefined) {
-      this.setVbrConstraint(options.vbrConstraint);
+    let configured = false;
+    try {
+      this.setBitrate(options.bitrate);
+      this.setComplexity(options.complexity);
+      this.setDtx(options.dtx);
+      this.setFec(options.fec);
+      if (options.maxBandwidth !== undefined) {
+        this.setMaxBandwidth(options.maxBandwidth);
+      }
+      this.setPacketLossPercent(options.packetLossPercent);
+      this.setSignal(options.signal);
+      if (options.vbr !== undefined) {
+        this.setVbr(options.vbr);
+      }
+      if (options.vbrConstraint !== undefined) {
+        this.setVbrConstraint(options.vbrConstraint);
+      }
+      configured = true;
+    } finally {
+      if (!configured) {
+        this.free();
+      }
     }
   }
 
@@ -779,18 +787,26 @@ function normalizeEncoderOptions(options: EncoderOptions): NormalizedEncoderOpti
   if (options.maxBandwidth !== undefined) {
     validateBandwidth(options.maxBandwidth, "maxBandwidth");
   }
+  const complexity = options.complexity ?? 10;
+  validateIntegerRange(complexity, 0, 10, "complexity");
+  const packetLossPercent = options.packetLossPercent ?? 0;
+  validateIntegerRange(packetLossPercent, 0, 100, "packetLossPercent");
+  const signal = options.signal ?? Signal.Auto;
+  if (!Object.values(Signal).includes(signal)) {
+    throw new RangeError("signal must be Signal.Auto, Signal.Voice, or Signal.Music");
+  }
   return {
     application: options.application ?? Application.Audio,
     bitrate: normalizeBitrate(options.bitrate ?? 64_000),
     channels,
-    complexity: options.complexity ?? 10,
+    complexity,
     dtx: options.dtx ?? false,
     fec: options.fec ?? false,
     frameSize,
     maxBandwidth: options.maxBandwidth,
-    packetLossPercent: options.packetLossPercent ?? 0,
+    packetLossPercent,
     sampleRate,
-    signal: options.signal ?? Signal.Auto,
+    signal,
     vbr: options.vbr,
     vbrConstraint: options.vbrConstraint,
   };

--- a/test/encoder-create-cleanup.test.ts
+++ b/test/encoder-create-cleanup.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type createLibopusModule from "../src/generated/libopus.generated.mjs";
+
+const lifecycle = {
+  created: 0,
+  destroyed: 0,
+  failNextEncoderCtl: false,
+};
+
+vi.mock("../src/generated/libopus.generated.mjs", async () => {
+  const actual = await vi.importActual<{ default: typeof createLibopusModule }>(
+    "../src/generated/libopus.generated.mjs",
+  );
+  return {
+    default: async () => {
+      const module = await actual.default();
+      const create = module._oc_create_encoder.bind(module);
+      const destroy = module._oc_destroy_encoder.bind(module);
+      const encoderCtl = module._oc_encoder_ctl.bind(module);
+      module._oc_create_encoder = (sampleRate, channels, application, errorPtr) => {
+        const ptr = create(sampleRate, channels, application, errorPtr);
+        if (ptr) {
+          lifecycle.created += 1;
+        }
+        return ptr;
+      };
+      module._oc_destroy_encoder = (ptr) => {
+        if (ptr) {
+          lifecycle.destroyed += 1;
+        }
+        destroy(ptr);
+      };
+      module._oc_encoder_ctl = (ptr, request, value) => {
+        if (lifecycle.failNextEncoderCtl) {
+          lifecycle.failNextEncoderCtl = false;
+          return -1;
+        }
+        return encoderCtl(ptr, request, value);
+      };
+      return module;
+    },
+  };
+});
+
+const { createEncoder, Signal } = await import("../src/index.js");
+
+describe("encoder create cleanup", () => {
+  beforeEach(() => {
+    lifecycle.created = 0;
+    lifecycle.destroyed = 0;
+    lifecycle.failNextEncoderCtl = false;
+  });
+
+  it("rejects invalid create-time tuning without allocating a native encoder", async () => {
+    await expect(createEncoder({ complexity: 11 })).rejects.toThrow(
+      /complexity must be an integer from 0 to 10/,
+    );
+    await expect(createEncoder({ packetLossPercent: 101 })).rejects.toThrow(
+      /packetLossPercent must be an integer from 0 to 100/,
+    );
+    await expect(createEncoder({ signal: 9999 as Signal })).rejects.toThrow(
+      /signal must be Signal.Auto, Signal.Voice, or Signal.Music/,
+    );
+
+    expect(lifecycle.created).toBe(0);
+    expect(lifecycle.destroyed).toBe(0);
+  });
+
+  it("destroys the native encoder if a post-create setter throws", async () => {
+    lifecycle.failNextEncoderCtl = true;
+
+    await expect(createEncoder()).rejects.toBeInstanceOf(Error);
+    expect(lifecycle.created).toBe(1);
+    expect(lifecycle.destroyed).toBe(1);
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

`createEncoder({ complexity: 11 })` (and the same pattern for `packetLossPercent` and `signal`) throws a `RangeError`, which is the documented public contract. The constructor still calls `_oc_create_encoder` first. The setter then throws. There is no handle for the caller to `free()`, and the constructor does not call `_oc_destroy_encoder`, so the native Opus encoder stays allocated in the shared WASM heap.

`docs/errors.md` says these argument `RangeError`s never reach WASM. `normalizeEncoderOptions` already rejects bad sample rates, channels, frame sizes, and max bandwidth before create. Complexity, packet loss, and signal were left to the post-create setters.

This change validates those three options before `_oc_create_encoder`, and wraps the post-create setters in `try`/`finally` so any later throw (including an `encoderCtl` failure) destroys `#ptr`.

## Evidence

Public API on the patched tree, macOS 26.6.2 arm64, Node.js v26.7.0:

```console
$ node /tmp/libopus-wasm-F001-proof.mjs
complexity: RangeError: complexity must be an integer from 0 to 10
complexity: handle returned: false
packetLossPercent: RangeError: packetLossPercent must be an integer from 0 to 100
packetLossPercent: handle returned: false
signal: RangeError: signal must be Signal.Auto, Signal.Voice, or Signal.Music
signal: handle returned: false
valid create: sampleRate=48000 channels=2 packetBytes=3
valid create: freed
```

Before this patch, instrumented `_oc_create_encoder` / `_oc_destroy_encoder` on the same public calls:

```console
createEncoder({ complexity: 11 })
createEncoder({ packetLossPercent: 101 })
createEncoder({ signal: 9999 })
created=3 destroyed=0
expected created to be 0
```

After this patch, the same three calls never allocate:

```console
created=0 destroyed=0
```

When a post-create setter still throws (forced `_oc_encoder_ctl` error after a successful native create):

```console
created=1 destroyed=1
```

Before the `finally` path, that case was `created=1 destroyed=0`.

Origin: [`7584d4fed01c`](https://github.com/openclaw/libopus-wasm/commit/7584d4fed01c798e2f1f27d30315af382b6a670e) (2026-05-26, Peter Steinberger, 95 days on `main`). No open or closed PR already fixes this. Sibling contract: [Errors](https://github.com/openclaw/libopus-wasm/blob/main/docs/errors.md). Native cleanup API: [opus_encoder_destroy](https://opus-codec.org/docs/html_api/group__opus__encoder.html).

## Real behavior proof

- **Behavior or issue addressed:** `createEncoder` leaked the native WASM encoder when create-time `complexity`, `packetLossPercent`, or `signal` failed after `_oc_create_encoder`. Callers never received a handle, so they could not call `free()`.
- **Real environment tested:** macOS 26.6.2 arm64, Node.js v26.7.0, branch `fix/f001-encoder-option-leak` at the commit of this PR, running the compiled `dist/index.js` plus instrumented `_oc_create_encoder` / `_oc_destroy_encoder` on the bundled WASM module.
- **Exact steps or command run after this patch:**

  ```bash
  node /tmp/libopus-wasm-F001-proof.mjs
  ```

- **Evidence after fix:** terminal output from the public `createEncoder` API:

  ```console
  $ node /tmp/libopus-wasm-F001-proof.mjs
  complexity: RangeError: complexity must be an integer from 0 to 10
  complexity: handle returned: false
  packetLossPercent: RangeError: packetLossPercent must be an integer from 0 to 100
  packetLossPercent: handle returned: false
  signal: RangeError: signal must be Signal.Auto, Signal.Voice, or Signal.Music
  signal: handle returned: false
  valid create: sampleRate=48000 channels=2 packetBytes=3
  valid create: freed
  ```

  Instrumented native lifecycle after the same invalid calls: `created=0 destroyed=0`. Forced post-create setter failure: `created=1 destroyed=1`.

- **Observed result after fix:** Invalid create-time tuning throws `RangeError` and returns no handle. The native encoder is not allocated for those inputs. If a setter still throws after `_oc_create_encoder`, `_oc_destroy_encoder` runs. A valid `createEncoder()` still encodes and `free()` still works.
- **What was not tested:** Browser `using` disposal, multi-threaded WASM, and decoder create (decoder has no post-create setters).

## Summary

- File: `src/index.ts`
- Tests: `test/encoder-create-cleanup.test.ts`
- Changelog: Unreleased note
- DCO: Signed-off-by
