### PR TITLE
fix: reject maxPacketBytes that do not fit in i32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Reject `maxPacketBytes` values that do not fit in a signed 32-bit integer so WASM malloc cannot wrap and poison the packet scratch buffer.
 - Update pnpm, Node.js types, Vite, Vitest and coverage tooling, refresh transitive dependency pins, and build CI with Emscripten 6.0.8 and setup-node v7.
 - Refresh pnpm, TypeScript, Node.js types, Vite, and GitHub Actions; pin patched transitive build tooling and extend CI coverage through Node.js 26.
 - Require Node.js 22 or newer for the npm package, matching the maintained CI matrix.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -140,7 +140,7 @@ Passed per `encode` / `encodeFloat` call.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `frameSize` | `number` | encoder default | Samples/channel for this frame. |
-| `maxPacketBytes` | `number` | `4000` | Output buffer ceiling. |
+| `maxPacketBytes` | `number` | `4000` | Output buffer ceiling. Must be an integer from 1 to 2147483647. |
 
 ### DecodeOptions
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,6 +149,7 @@ const DEFAULT_CHANNELS = 2 satisfies ChannelCount;
 const DEFAULT_FRAME_DURATION_MS = 20;
 const MAX_PACKET_DURATION_MS = 120;
 const DEFAULT_MAX_PACKET_BYTES = 4000;
+const MAX_I32 = 0x7fff_ffff;
 const DEFAULT_SAMPLE_RATE = 48_000 satisfies SampleRate;
 const DECODER_INTEGER_CTL_REQUESTS = new Set<number>(Object.values(DecoderCtl));
 const ENCODER_INTEGER_CTL_REQUESTS = new Set<number>(Object.values(EncoderCtl));
@@ -309,7 +310,7 @@ class WasmOpusEncoder implements OpusEncoderHandle {
       );
     }
     const maxPacketBytes = options.maxPacketBytes ?? DEFAULT_MAX_PACKET_BYTES;
-    validatePositiveInteger(maxPacketBytes, "maxPacketBytes");
+    validateIntegerRange(maxPacketBytes, 1, MAX_I32, "maxPacketBytes");
     const pcmPtr = this.#ensurePcmBytes(pcmBytes.byteLength);
     const packetPtr = this.#ensurePacketBytes(maxPacketBytes);
     this.#module.HEAPU8.set(pcmBytes, pcmPtr);
@@ -337,7 +338,7 @@ class WasmOpusEncoder implements OpusEncoderHandle {
       );
     }
     const maxPacketBytes = options.maxPacketBytes ?? DEFAULT_MAX_PACKET_BYTES;
-    validatePositiveInteger(maxPacketBytes, "maxPacketBytes");
+    validateIntegerRange(maxPacketBytes, 1, MAX_I32, "maxPacketBytes");
     const pcmPtr = this.#ensurePcmBytes(pcm.byteLength);
     const packetPtr = this.#ensurePacketBytes(maxPacketBytes);
     this.#module.HEAPF32.set(pcm, pcmPtr >> 2);
@@ -897,6 +898,7 @@ function validateIntegerRange(value: number, min: number, max: number, name: str
 }
 
 function checkedMalloc(module: LibopusModule, bytes: number): number {
+  validateIntegerRange(bytes, 1, MAX_I32, "malloc size");
   const ptr = module._malloc(bytes);
   if (ptr === 0) {
     throw new Error(`WASM malloc failed for ${bytes} bytes`);

--- a/test/max-packet-bytes.test.ts
+++ b/test/max-packet-bytes.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { createEncoder } from "../src/index.js";
+
+describe("maxPacketBytes i32 bounds", () => {
+  it("rejects sizes that do not fit in a positive i32 and does not poison scratch", async () => {
+    const encoder = await createEncoder({ channels: 1, sampleRate: 8000 });
+    try {
+      const pcm = makeSineFrame(encoder.frameSize, 1);
+      const tooBig = /maxPacketBytes must be an integer from 1 to 2147483647/;
+
+      expect(() => encoder.encode(pcm, { maxPacketBytes: 2 ** 32 })).toThrow(tooBig);
+      expect(() => encoder.encode(pcm, { maxPacketBytes: 2 ** 32 + 16 })).toThrow(tooBig);
+      expect(() => encoder.encode(pcm, { maxPacketBytes: 2 ** 31 })).toThrow(tooBig);
+      expect(() => encoder.encodeFloat(new Float32Array(pcm.length), { maxPacketBytes: 2 ** 32 })).toThrow(
+        tooBig,
+      );
+
+      const packet = encoder.encode(pcm);
+      expect(packet.byteLength).toBeGreaterThan(0);
+      expect(packet.byteLength).toBeLessThanOrEqual(4000);
+
+      const again = encoder.encode(pcm, { maxPacketBytes: 4000 });
+      expect(again.byteLength).toBeGreaterThan(0);
+    } finally {
+      encoder.free();
+    }
+  });
+});
+
+function makeSineFrame(frameSize: number, channels: 1 | 2): Int16Array {
+  const pcm = new Int16Array(frameSize * channels);
+  for (let sample = 0; sample < frameSize; sample += 1) {
+    const value = Math.round(Math.sin((sample / frameSize) * Math.PI * 2) * 8000);
+    for (let channel = 0; channel < channels; channel += 1) {
+      pcm[sample * channels + channel] = value;
+    }
+  }
+  return pcm;
+}


### PR DESCRIPTION
## What Problem This Solves

`encode` / `encodeFloat` accept any positive JS integer for `maxPacketBytes`. WASM32 `_malloc` and `_oc_encode` take signed i32. `2 ** 32` becomes 0 and `2 ** 32 + 16` becomes 16. `checkedMalloc` still succeeds (`malloc(0)` and `malloc(16)` return non-null). `#packetBytes` is stored as the huge JS number.

The next `encode` with the default 4000-byte cap sees `#packetBytes >= 4000` and reuses that tiny scratch. `opus_encode` then writes a full packet (75 bytes in the live repro) past the allocation.

`docs/errors.md` says argument `RangeError`s never reach WASM. `maxPacketBytes: 0` already throws `RangeError`. Values that only fail after i32 wrap were leaking through to native encode.

This change rejects `maxPacketBytes` outside `1..2147483647` before malloc, and `checkedMalloc` applies the same bound so `#packetBytes` is only recorded for a size that was actually allocated.

## Evidence

Public API on the unfixed tree (`/tmp/oc-pr-libopus-wasm-F001/dist/index.js`), macOS 26.6.2 arm64, Node.js v26.7.0:

```console
$ node -e 'import { createEncoder } from "/tmp/oc-pr-libopus-wasm-F001/dist/index.js"; ...'
2**32: OpusError: libopus encode failed (-1): invalid argument
2**32+16: unexpectedly succeeded bytes=7
2**31: OpusError: libopus encode failed (-1): invalid argument
default after rejects: bytes=75
freed
```

`2 ** 32 + 16` wraps to 16, stores `#packetBytes = 4294967312`, and the following default encode writes 75 bytes into that 16-byte scratch.

Public API on the patched tree, same machine:

```console
$ node /tmp/libopus-wasm-F002-proof.mjs
2**32: RangeError: maxPacketBytes must be an integer from 1 to 2147483647
2**32+16: RangeError: maxPacketBytes must be an integer from 1 to 2147483647
2**31: RangeError: maxPacketBytes must be an integer from 1 to 2147483647
default after rejects: bytes=3
explicit 4000 after rejects: bytes=3
freed
```

Origin: [`7584d4fed01c`](https://github.com/openclaw/libopus-wasm/commit/7584d4fed01c798e2f1f27d30315af382b6a670e) (2026-05-26, Peter Steinberger, 95 days on `main`). Scratch cache that stores the JS size: [`9927e91d`](https://github.com/openclaw/libopus-wasm/commit/9927e91d). No open or closed PR already fixes this. Same class as [emscripten#11160](https://github.com/emscripten-core/emscripten/issues/11160) (`Module._malloc` i32 wrap). Sibling contract: [Errors](https://github.com/openclaw/libopus-wasm/blob/main/docs/errors.md).

## Real behavior proof

- **Behavior or issue addressed:** `maxPacketBytes` values that do not fit in a positive i32 wrapped at the WASM32 boundary, poisoned the packet scratch cache, and let a later default `encode` write past the allocation.
- **Real environment tested:** macOS 26.6.2 arm64, Node.js v26.7.0, branch `fix/f002-max-packet-i32` at the commit of this PR, running compiled `dist/index.js`.
- **Exact steps or command run after this patch:**

  ```bash
  node /tmp/libopus-wasm-F002-proof.mjs
  ```

- **Evidence after fix:** terminal output from the public `createEncoder` / `encode` API:

  ```console
  $ node /tmp/libopus-wasm-F002-proof.mjs
  2**32: RangeError: maxPacketBytes must be an integer from 1 to 2147483647
  2**32+16: RangeError: maxPacketBytes must be an integer from 1 to 2147483647
  2**31: RangeError: maxPacketBytes must be an integer from 1 to 2147483647
  default after rejects: bytes=3
  explicit 4000 after rejects: bytes=3
  freed
  ```

- **Observed result after fix:** Oversized `maxPacketBytes` throws `RangeError` and does not call WASM encode or cache a wrapped malloc. A later default `encode` and an explicit 4000-byte encode both succeed.
- **What was not tested:** Browser `using` disposal, multi-threaded WASM, and decoder output scratch (decoder has no `maxPacketBytes`).

## Summary

- File: `src/index.ts`
- Tests: `test/max-packet-bytes.test.ts`
- Changelog: Unreleased note
- DCO: Signed-off-by
