### PR TITLE
fix: cap decode and getPacketInfo packet malloc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Reject decode and `getPacketInfo` packets larger than 64 KiB before WASM malloc so an oversized buffer cannot force a large heap allocation. Thanks @SebTardif.
 - Reject `maxPacketBytes` values that do not fit in a signed 32-bit integer so WASM malloc cannot wrap and poison the packet scratch buffer. (#11) Thanks @SebTardif.
 - Destroy the native encoder if post-create option setters throw, and reject invalid `complexity`, `packetLossPercent`, and `signal` before WASM create. (#10) Thanks @SebTardif.
 - Update pnpm, Node.js types, Vite, Vitest and coverage tooling, refresh transitive dependency pins, and build CI with Emscripten 6.0.8 and setup-node v7.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -208,8 +208,8 @@ Integer request codes for the CTL passthrough. See the
 Use `OpusErrorCode` for named libopus error codes and `isOpusError(error)` for
 realm-safe checks.
 
-Argument validation (wrong frame size, out-of-range option, empty packet,
-non-allow-listed CTL) throws a plain `RangeError` _before_ reaching WASM. Using a
+Argument validation (wrong frame size, out-of-range option, empty or oversized
+packet, non-allow-listed CTL) throws a plain `RangeError` _before_ reaching WASM. Using a
 handle after `free()` throws a plain `Error`. See [Errors & validation](errors.md)
 for the full breakdown.
 
@@ -221,6 +221,7 @@ for the full breakdown.
 | Channels | `1` (mono), `2` (stereo) |
 | Encode frame duration | `2.5`, `5`, `10`, `20`, `40`, `60` ms |
 | Decode output capacity | up to `120` ms |
+| Decode / `getPacketInfo` packet | at most `65536` bytes |
 | PLC / FEC frame size | multiples of `2.5` ms, from `2.5` to `120` ms |
 
 ## Types

--- a/docs/decoding.md
+++ b/docs/decoding.md
@@ -90,8 +90,9 @@ try {
 ```
 
 Passing an **empty** `Uint8Array` is a different mistake and throws a
-`RangeError` — use `null` (or `decodePacketLoss`) to signal a lost packet, not a
-zero-length buffer.
+`RangeError`. Use `null` (or `decodePacketLoss`) to signal a lost packet, not a
+zero-length buffer. Packets larger than 64 KiB also throw a `RangeError` before
+any WASM allocation.
 
 ## Next
 

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -9,8 +9,8 @@ or truncated packet.
 ## RangeError: bad arguments
 
 Every option and buffer is checked up front. A wrong frame size, an
-out-of-range option, an empty packet, or a CTL request outside the allow-list
-throws synchronously with a `RangeError`:
+out-of-range option, an empty or oversized packet (larger than 64 KiB), or a
+CTL request outside the allow-list throws synchronously with a `RangeError`:
 
 ```ts
 encoder.encode(new Int16Array(123)); // RangeError: wrong sample count

--- a/docs/packet-info.md
+++ b/docs/packet-info.md
@@ -65,8 +65,8 @@ const frame = decoder.decode(packet);
 ## Invalid packets
 
 A corrupt or truncated packet surfaces the libopus error as an
-[`OpusError`](errors.md); an empty `Uint8Array` throws a `RangeError` before
-reaching WASM.
+[`OpusError`](errors.md). An empty `Uint8Array`, or a packet larger than
+64 KiB, throws a `RangeError` before reaching WASM.
 
 ```ts
 import { OpusError } from "libopus-wasm";

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,6 +149,7 @@ const DEFAULT_CHANNELS = 2 satisfies ChannelCount;
 const DEFAULT_FRAME_DURATION_MS = 20;
 const MAX_PACKET_DURATION_MS = 120;
 const DEFAULT_MAX_PACKET_BYTES = 4000;
+const MAX_DECODE_PACKET_BYTES = 64 * 1024;
 const MAX_I32 = 0x7fff_ffff;
 const DEFAULT_SAMPLE_RATE = 48_000 satisfies SampleRate;
 const DECODER_INTEGER_CTL_REQUESTS = new Set<number>(Object.values(DecoderCtl));
@@ -207,6 +208,7 @@ export async function getPacketInfo(
   if (packet.byteLength === 0) {
     throw new RangeError("packet must not be empty");
   }
+  validateDecodePacketBytes(packet.byteLength);
   const module = await getModule();
   const packetPtr = checkedMalloc(module, packet.byteLength);
   try {
@@ -649,12 +651,14 @@ class WasmOpusDecoder implements OpusDecoderHandle {
     if (packet.byteLength === 0) {
       throw new RangeError("packet must not be empty; use null or decodePacketLoss() for PLC");
     }
+    validateDecodePacketBytes(packet.byteLength);
     const packetPtr = this.#ensurePacketBytes(packet.byteLength);
     this.#module.HEAPU8.set(packet, packetPtr);
     return { packetLength: packet.byteLength, packetPtr };
   }
 
   #ensurePacketBytes(requiredBytes: number): number {
+    validateDecodePacketBytes(requiredBytes);
     if (this.#packetPtr !== 0 && this.#packetBytes >= requiredBytes) {
       return this.#packetPtr;
     }
@@ -910,6 +914,14 @@ function validatePositiveInteger(value: number, name: string): void {
 function validateIntegerRange(value: number, min: number, max: number, name: string): void {
   if (!Number.isInteger(value) || value < min || value > max) {
     throw new RangeError(`${name} must be an integer from ${min} to ${max}`);
+  }
+}
+
+function validateDecodePacketBytes(byteLength: number): void {
+  if (byteLength > MAX_DECODE_PACKET_BYTES) {
+    throw new RangeError(
+      `packet must be at most ${MAX_DECODE_PACKET_BYTES} bytes; got ${byteLength}`,
+    );
   }
 }
 

--- a/test/decode-packet-size.test.ts
+++ b/test/decode-packet-size.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { createDecoder, createEncoder, getPacketInfo } from "../src/index.js";
+
+const MAX_DECODE_PACKET_BYTES = 64 * 1024;
+
+describe("decode and getPacketInfo packet size cap", () => {
+  it("rejects packets larger than 64 KiB before malloc", async () => {
+    const hugePacket = new Uint8Array(MAX_DECODE_PACKET_BYTES + 1);
+    const tooBig = /packet must be at most 65536 bytes/;
+
+    await expect(getPacketInfo(hugePacket)).rejects.toThrow(RangeError);
+    await expect(getPacketInfo(hugePacket)).rejects.toThrow(tooBig);
+
+    const decoder = await createDecoder();
+    try {
+      expect(() => decoder.decode(hugePacket)).toThrow(RangeError);
+      expect(() => decoder.decode(hugePacket)).toThrow(tooBig);
+    } finally {
+      decoder.free();
+    }
+  });
+
+  it("still inspects and decodes a valid small packet", async () => {
+    const encoder = await createEncoder({ channels: 1, sampleRate: 8000 });
+    const decoder = await createDecoder({ channels: 1, sampleRate: 8000 });
+    try {
+      const packet = encoder.encode(makeSineFrame(encoder.frameSize, 1));
+      const info = await getPacketInfo(packet, { sampleRate: 8000 });
+      const decoded = decoder.decode(packet);
+
+      expect(packet.byteLength).toBeGreaterThan(0);
+      expect(packet.byteLength).toBeLessThanOrEqual(MAX_DECODE_PACKET_BYTES);
+      expect(info.channels).toBe(1);
+      expect(info.samples).toBe(encoder.frameSize);
+      expect(decoded.length).toBe(encoder.frameSize);
+    } finally {
+      encoder.free();
+      decoder.free();
+    }
+  });
+});
+
+function makeSineFrame(frameSize: number, channels: 1 | 2): Int16Array {
+  const pcm = new Int16Array(frameSize * channels);
+  for (let sample = 0; sample < frameSize; sample += 1) {
+    const value = Math.round(Math.sin((sample / frameSize) * Math.PI * 2) * 8000);
+    for (let channel = 0; channel < channels; channel += 1) {
+      pcm[sample * channels + channel] = value;
+    }
+  }
+  return pcm;
+}


### PR DESCRIPTION
## What Problem This Solves

`getPacketInfo` and `decoder.decode` copy the caller's packet into the WASM heap with `checkedMalloc(packet.byteLength)`. Encode already caps its output buffer (`maxPacketBytes`, default 4000). Decode does not. Any i32-sized buffer is allocated first; libopus only rejects the payload after that copy.

That is the Discord / network path: `discordjs.ts` forwards the received buffer to `decoder.decode`. A multi-megabyte packet forces a large WASM heap allocation before the codec can say the bytes are invalid.

`docs/errors.md` says argument `RangeError`s never reach WASM. Empty packets already throw `RangeError`. Oversized packets were leaking through to malloc.

This change rejects packets above 64 KiB (`MAX_DECODE_PACKET_BYTES`) in `getPacketInfo`, `#copyPacket`, and the decoder `#ensurePacketBytes` before any allocation. Encode `maxPacketBytes` is unchanged. 64 KiB is above the RFC 6716 multi-frame ceiling (48 frames * 1275 = 61200).

## Evidence

Public API on the patched tree, macOS 26.6.2 arm64, Node.js v26.7.0:

```console
$ node /tmp/libopus-f003-proof.mjs
getPacketInfo(65KiB): RangeError: packet must be at most 65536 bytes; got 66560
decode(65KiB): RangeError: packet must be at most 65536 bytes; got 66560
small packet: bytes=3 samples=160 decoded=160
```

On origin/main the same 65537-byte `getPacketInfo` call returned `OpusError: libopus getPacketInfo failed (-4): corrupted stream` after malloc. A 65 KiB buffer now throws `RangeError` and never reaches `_malloc`.

Origin of the unbounded `getPacketInfo` copy: [`efa02634ef92`](https://github.com/openclaw/libopus-wasm/commit/efa02634ef923a73df6b309cf72668c4fc237fc6) (2026-05-26, Peter Steinberger, 99 days on `main`). Decoder `#copyPacket` is from [`9927e91d250c`](https://github.com/openclaw/libopus-wasm/commit/9927e91d250c77b71d67eaee9862c14048f77c42). [#11](https://github.com/openclaw/libopus-wasm/pull/11) only added native i32 bounds; it still mallocs any packet that fits in `MAX_I32`. No open PR already caps decode input.

## Real behavior proof

- **Behavior or issue addressed:** `getPacketInfo` and `decoder.decode` allocated the full untrusted packet in the WASM heap before libopus could reject it. Packets above 64 KiB now throw `RangeError` first.
- **Real environment tested:** macOS 26.6.2 arm64, Node.js v26.7.0, branch `fix/decode-packet-size-cap`, running compiled `dist/index.js`.
- **Exact steps or command run after this patch:**

  ```bash
  node /tmp/libopus-f003-proof.mjs
  ```

- **Evidence after fix:** terminal output from the public `getPacketInfo` / `createDecoder` / `decode` API:

  ```console
  $ node /tmp/libopus-f003-proof.mjs
  getPacketInfo(65KiB): RangeError: packet must be at most 65536 bytes; got 66560
  decode(65KiB): RangeError: packet must be at most 65536 bytes; got 66560
  small packet: bytes=3 samples=160 decoded=160
  ```

- **Observed result after fix:** A 65 KiB buffer throws `RangeError` from both `getPacketInfo` and `decode`. A valid 3-byte Opus packet still inspects and decodes (160 samples at 8 kHz).
- **What was not tested:** Browser `using` disposal, multi-threaded WASM, and a crafted multi-frame packet between 61201 and 65536 bytes.

## Summary

- File: `src/index.ts`
- Coverage: `test/decode-packet-size.test.ts`
- Docs: packet size limit on decode / `getPacketInfo`
- Changelog: Unreleased note
- DCO: Signed-off-by
