### PR TITLE
build: refresh pnpm, Node types, and Emscripten

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: emscripten-core/setup-emsdk@v16
         with:
-          version: 6.0.8
+          version: 6.0.9
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm benchmark

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: emscripten-core/setup-emsdk@v16
         with:
-          version: 6.0.8
+          version: 6.0.9
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Update pnpm to 11.25.0 and Node.js types to 26.4.1, and build CI with Emscripten 6.0.9.
 - Reject `maxPacketBytes` values that do not fit in a signed 32-bit integer so WASM malloc cannot wrap and poison the packet scratch buffer. (#11) Thanks @SebTardif.
 - Destroy the native encoder if post-create option setters throw, and reject invalid `complexity`, `packetLossPercent`, and `signal` before WASM create. (#10) Thanks @SebTardif.
 - Update pnpm, Node.js types, Vite, Vitest and coverage tooling, refresh transitive dependency pins, and build CI with Emscripten 6.0.8 and setup-node v7.

--- a/docs/building.md
+++ b/docs/building.md
@@ -6,7 +6,7 @@ toolchain, pin a different libopus, or hack on the bindings.
 
 ## Prerequisites
 
-- [Emscripten](https://emscripten.org/) (`emcc`) on your `PATH`; CI uses version 6.0.8.
+- [Emscripten](https://emscripten.org/) (`emcc`) on your `PATH`; CI uses version 6.0.9.
 - [pnpm](https://pnpm.io/) — the repo's package manager.
 - Node 22 or newer.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "libopus-wasm",
   "version": "0.2.0",
-  "packageManager": "pnpm@11.24.0",
+  "packageManager": "pnpm@11.25.0",
   "description": "Small, modern WASM bindings for libopus raw packet encode/decode.",
   "type": "module",
   "sideEffects": false,
@@ -48,7 +48,7 @@
   },
   "devDependencies": {
     "@discordjs/opus": "0.10.0",
-    "@types/node": "26.4.0",
+    "@types/node": "26.4.1",
     "@vitest/coverage-v8": "4.1.11",
     "typescript": "^7.0.2",
     "vite": "8.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
         specifier: 0.10.0
         version: 0.10.0(supports-color@7.2.0)
       '@types/node':
-        specifier: 26.4.0
-        version: 26.4.0
+        specifier: 26.4.1
+        version: 26.4.1
       '@vitest/coverage-v8':
         specifier: 4.1.11
         version: 4.1.11(vitest@4.1.11)
@@ -26,10 +26,10 @@ importers:
         version: 7.0.2
       vite:
         specifier: 8.2.2
-        version: 8.2.2(@types/node@26.4.0)
+        version: 8.2.2(@types/node@26.4.1)
       vitest:
         specifier: 4.1.11
-        version: 4.1.11(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.4.0))
+        version: 4.1.11(@types/node@26.4.1)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.4.1))
 
 packages:
 
@@ -190,8 +190,8 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
-  '@types/node@26.4.0':
-    resolution: {integrity: sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==}
+  '@types/node@26.4.1':
+    resolution: {integrity: sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA==}
 
   '@typescript/typescript-aix-ppc64@7.0.2':
     resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
@@ -964,7 +964,7 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
-  '@types/node@26.4.0':
+  '@types/node@26.4.1':
     dependencies:
       undici-types: 8.3.0
 
@@ -1040,7 +1040,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.11(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.4.0))
+      vitest: 4.1.11(@types/node@26.4.1)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.4.1))
 
   '@vitest/expect@4.1.11':
     dependencies:
@@ -1051,13 +1051,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.1.11(vite@8.2.2(@types/node@26.4.0))':
+  '@vitest/mocker@4.1.11(vite@8.2.2(@types/node@26.4.1))':
     dependencies:
       '@vitest/spy': 4.1.11
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.2.2(@types/node@26.4.0)
+      vite: 8.2.2(@types/node@26.4.1)
 
   '@vitest/pretty-format@4.1.11':
     dependencies:
@@ -1447,7 +1447,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite@8.2.2(@types/node@26.4.0):
+  vite@8.2.2(@types/node@26.4.1):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.7
@@ -1455,13 +1455,13 @@ snapshots:
       rolldown: 1.2.6
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 26.4.0
+      '@types/node': 26.4.1
       fsevents: 2.3.3
 
-  vitest@4.1.11(@types/node@26.4.0)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.4.0)):
+  vitest@4.1.11(@types/node@26.4.1)(@vitest/coverage-v8@4.1.11)(vite@8.2.2(@types/node@26.4.1)):
     dependencies:
       '@vitest/expect': 4.1.11
-      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.4.0))
+      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@26.4.1))
       '@vitest/pretty-format': 4.1.11
       '@vitest/runner': 4.1.11
       '@vitest/snapshot': 4.1.11
@@ -1478,10 +1478,10 @@ snapshots:
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: 8.2.2(@types/node@26.4.0)
+      vite: 8.2.2(@types/node@26.4.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 26.4.0
+      '@types/node': 26.4.1
       '@vitest/coverage-v8': 4.1.11(vitest@4.1.11)
     transitivePeerDependencies:
       - msw


### PR DESCRIPTION
Refresh the development toolchain to pnpm 11.25.0, Node.js types 26.4.1, and Emscripten 6.0.9. Keep the Node 22/24/26 test matrix and the established libopus compiler/linker optimization settings. Regenerate the lockfile and update the build documentation and Unreleased changelog.

The dependency audit found the other direct dependencies and GitHub Action major pins current. Existing tar and semver overrides remain current.

Validation on macOS arm64:
- `pnpm install --frozen-lockfile`: passed with pnpm 11.25.0.
- `pnpm build`: fresh libopus 1.6.1 WASM build passed with Emscripten 6.0.9.
- `pnpm test`: all 25 tests in 4 files passed.
- `pnpm typecheck` and `pnpm docs:build`: passed; 15 documentation pages built.
- `pnpm pack --dry-run` and `pnpm pack --out /tmp/libopus-wasm.tgz`: passed.
- Installed that tarball into a separate consumer using `pnpm add --ignore-scripts /tmp/libopus-wasm.tgz`. Real ESM imports of both package entry points passed under Node 24.20.0 and 26.8.1 across all five sample rates and both channel counts. Verified Int16/Float32 encode/decode, packet metadata, PLC, FEC, batches, and the Discord adapter.
- `pnpm audit --json`: zero vulnerabilities; `pnpm outdated --format json`: no outdated direct dependencies.
- Isolated Codex autoreview through P2: no actionable findings.

The following core smoke check runs from the tarball consumer directory and passed on both Node versions:

```js
import assert from 'node:assert/strict';
import { createEncoder, createDecoder, getPacketInfo, loadLibopus } from 'libopus-wasm';
import { OpusEncoder } from 'libopus-wasm/discordjs';
for (const sampleRate of [8000, 12000, 16000, 24000, 48000]) {
  for (const channels of [1, 2]) {
    const encoder = await createEncoder({ sampleRate, channels });
    const decoder = await createDecoder({ sampleRate, channels });
    try {
      const pcm = new Int16Array(encoder.frameSize * channels);
      const packet = encoder.encode(pcm);
      assert.equal((await getPacketInfo(packet, { sampleRate })).samples, encoder.frameSize);
      assert.equal(decoder.decode(packet).length, pcm.length);
      assert.equal(decoder.decodeFloat(packet).length, pcm.length);
    } finally { encoder.free(); decoder.free(); }
  }
}
const adapter = await OpusEncoder.create();
try { assert.equal(adapter.decode(adapter.encode(Buffer.alloc(3840))).length, 3840); }
finally { adapter.free(); }
console.log((await loadLibopus()).version, '10 configurations + Discord adapter passed');
```

A 20,000-iteration native/WASM benchmark also passed using Node 24, matching the locally installed native addon's ABI: WASM encode 14,515 ops/sec, native encode 14,899; WASM decode 36,319, native decode 40,987. These are local smoke/performance observations, not portable performance guarantees. An initial benchmark invocation under Node 26 could not load the Node 24 native-addon path; using the matching runtime resolved that local tooling mismatch. The WASM tarball itself passed both runtimes.

CI for this head: [Node 22/24/26 workflow](https://github.com/openclaw/libopus-wasm/actions/runs/33850772376). All three jobs passed on this exact head. Node 22 spent several minutes in pnpm setup before progressing and passing; no rerun was needed. No merge performed.
