### PR TITLE
chore(release): prepare libopus-wasm 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,14 @@
 
 ## Unreleased
 
+## 0.3.0 - 2026-09-04
+
+- Raise the minimum supported Node.js version from 20 to 22.
 - Update pnpm to 11.25.0 and Node.js types to 26.4.1, and build CI with Emscripten 6.0.9.
 - Reject `maxPacketBytes` values that do not fit in a signed 32-bit integer so WASM malloc cannot wrap and poison the packet scratch buffer. (#11) Thanks @SebTardif.
 - Destroy the native encoder if post-create option setters throw, and reject invalid `complexity`, `packetLossPercent`, and `signal` before WASM create. (#10) Thanks @SebTardif.
 - Update pnpm, Node.js types, Vite, Vitest and coverage tooling, refresh transitive dependency pins, and build CI with Emscripten 6.0.8 and setup-node v7.
 - Refresh pnpm, TypeScript, Node.js types, Vite, and GitHub Actions; pin patched transitive build tooling and extend CI coverage through Node.js 26.
-- Require Node.js 22 or newer for the npm package, matching the maintained CI matrix.
 
 ## 0.2.0 - 2026-06-01
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libopus-wasm",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "packageManager": "pnpm@11.25.0",
   "description": "Small, modern WASM bindings for libopus raw packet encode/decode.",
   "type": "module",


### PR DESCRIPTION
## Summary

Prepare `libopus-wasm` 0.3.0 for publication.

This release includes the packet-size bounds fix, failed-encoder cleanup, the
Emscripten 6.0.9 toolchain refresh, and the already-landed Node.js 22 minimum.
The Node engine change makes this a 0.3.0 release rather than a patch release.

## Validation

- Clean Emscripten 6.0.9 build from pinned libopus 1.6.1 source
- 25 tests passed
- TypeScript typecheck passed
- Package smoke passed for the main and `discordjs` exports on Node.js 26
- Packed tarball SHA-256: `932f731624784df01606bf0042640f23964fc6fed09199b2a225d4177f0a75d5`
- Benchmark: 17,838 encode ops/sec and 43,171 decode ops/sec
- Independent release review: approved with no findings

Publication will follow after this exact head passes hosted CI and lands.

Punchcard-Session: golden-summit-workshop-vd
