### PR TITLE
docs: prepare complete release notes since v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## Unreleased
 
-- Update Vitest and V8 coverage tooling to 5.0.0; running the test suite now requires Node.js 22.12 or newer.
-- Update pnpm to 11.25.0 and Node.js types to 26.4.1, and build CI with Emscripten 6.0.9.
-- Reject `maxPacketBytes` values that do not fit in a signed 32-bit integer so WASM malloc cannot wrap and poison the packet scratch buffer. (#11) Thanks @SebTardif.
-- Destroy the native encoder if post-create option setters throw, and reject invalid `complexity`, `packetLossPercent`, and `signal` before WASM create. (#10) Thanks @SebTardif.
-- Update pnpm, Node.js types, Vite, Vitest and coverage tooling, refresh transitive dependency pins, and build CI with Emscripten 6.0.8 and setup-node v7.
-- Refresh pnpm, TypeScript, Node.js types, Vite, and GitHub Actions; pin patched transitive build tooling and extend CI coverage through Node.js 26.
-- Require Node.js 22 or newer for the npm package, matching the maintained CI matrix.
+**Highlights:** Safer encoder initialization and packet-size handling, plus reliable documentation navigation. The next release requires Node.js 22 or newer.
+
+- Reject `maxPacketBytes` values outside signed 32-bit bounds so WASM allocation cannot wrap and poison the packet scratch buffer. (#11) Thanks @SebTardif.
+- Free native encoders when post-create option setters fail, and validate `complexity`, `packetLossPercent`, and `signal` before native encoder creation. (#10) Thanks @SebTardif.
+- Generate documentation table-of-contents links from rendered headings so code-formatted, repeated, and punctuated headings link correctly. (#7) Thanks @vincentkoc.
+- Raise the minimum supported Node.js version from 20 to 22.
+- Refresh pnpm to 11.25.0, TypeScript to 7.0.2, Node.js types to 26.4.1, Vite to 8.2.2, and Vitest and V8 coverage to 5.0.0; refresh transitive dependencies and GitHub Actions, build with Emscripten 6.0.9, and test through Node.js 26. Running the test suite requires Node.js 22.12 or newer.
 
 ## 0.2.0 - 2026-06-01
 


### PR DESCRIPTION
Rebuild the Unreleased notes from every user-visible change since v0.2.0: lead with encoder safety fixes, restore the missing documentation-navigation fix and contributor credit, state the Node.js 22 compatibility change, and consolidate the final toolchain versions.

This carries forward the preparation in #15, thanks @vincentkoc. Package version and release date remain unchanged until publication is authorized. Maintenance ordinarily warrants a patch, but the already-landed removal of Node.js 20 support warrants an explicit compatibility decision before assigning a version.

This PR is stacked on #16. Merge #16 first without deleting its branch, then retarget this PR to main and squash it. No release or publication is part of this PR.

Validation:
- Fresh Emscripten 6.0.9 build of pinned libopus 1.6.1; all 25 tests passed under Vitest 5, with 94.59% line coverage; typecheck passed.
- Packed the built output with pnpm, installed the tarball into an isolated consumer, and exercised both public exports on Node.js 24.20.0 and 26.8.1.
- Real Int16/Float32 codec integration across all supported sample rates and channel counts, PLC/FEC calls, packet metadata, invalid-input recovery, and the Discord adapter passed.
- The packed changelog matches this head byte-for-byte; previously released changelog sections are unchanged. The tarball retains version 0.2.0 for preparation only and is not a publication candidate.
- Tarball SHA-256: `a914534c72a500e1b5b82a6e773b9a2ec599bba7fb9e0c7e3a7b304f7bc8d8e8`.
- Codex local and committed-branch autoreview: scoped-clean through P2.

Hosted CI: https://github.com/openclaw/libopus-wasm/actions/runs/33988384100
